### PR TITLE
add selector for libgcc pins to fix 1.3 builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,9 @@ requirements:
   build:
     - {{ compiler('c') }}
     - pkg-config {{ pkg_config }}
+    # Use pins to control cos6/cos7 match
+    - libgcc-ng  {{ libgcc }}         # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}   # [x86_64 and c_compiler_version == "7.2.*"]
   host:
     - python {{ python }}
     - pip {{ pip }}
@@ -29,6 +32,9 @@ requirements:
     - numpy {{ numpy }}
     - ffmpeg {{ ffmpeg }}
     - pillow {{ pillow }}
+    # Use pins to control cos6/cos7 match
+    - libgcc-ng  {{ libgcc }}         # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}   # [x86_64 and c_compiler_version == "7.2.*"]
   run:
     - python {{ python }}
     - numpy {{ numpy }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   run_exports:
     # PyAV now claims to follow semantic versioning

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,9 +22,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - pkg-config {{ pkg_config }}
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
   host:
     - python {{ python }}
     - pip {{ pip }}
@@ -32,9 +29,6 @@ requirements:
     - numpy {{ numpy }}
     - ffmpeg {{ ffmpeg }}
     - pillow {{ pillow }}
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
   run:
     - python {{ python }}
     - numpy {{ numpy }}


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Requires - open-ce/open-ce#501
Remove compiler pins as these are no longer required now, since we are moving to GCC 7.5 on x86.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
