### PR TITLE
update for pkgconfig pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   run_exports:
     # PyAV now claims to follow semantic versioning
@@ -21,7 +21,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}             #[ppc_arch != "p10"]
-    - pkg-config {{ pkg_config }}
+    - pkg-config {{ pkgconfig }}
   host:
     - python {{ python }}
     - pip {{ pip }}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

ffmpeg build via opence fails with `error: gnutls not found using pkg-config`. 
Updating the pkg_config pin name to pkgconfig helps. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
